### PR TITLE
nomad-filebeat: fix log treatment in filebeat tmpl for api router

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,11 @@ RUN set -ex \
   && rm sigil.tgz \
   && apk del curl
 
-ENV FILEBEAT_VERSION=1.3.1 \
-    FILEBEAT_SHA1=693c04e2251498e73436cfc2b36a3a0aec920a2d
+ENV FILEBEAT_VERSION=5.5.1 \
+    FILEBEAT_SHA1=2a348d116d5225327af0a9a54702889366af971e
 RUN set -ex \
   && apk add --no-cache curl \
-  && curl -Lo filebeat.tgz "https://download.elastic.co/beats/filebeat/filebeat-${FILEBEAT_VERSION}-x86_64.tar.gz" \
+  && curl -Lo filebeat.tgz "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-linux-x86_64.tar.gz" \
   && echo "${FILEBEAT_SHA1}  filebeat.tgz" | sha1sum -c - \
   && tar xzf filebeat.tgz \
   && cp filebeat-*/filebeat /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from frolvlad/alpine-glibc:alpine-3.4
+FROM frolvlad/alpine-glibc:alpine-3.4
 
 # install dumb-init, a simple process supervisor and init system
 ENV DUMB_INIT_VERSION 1.1.3

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -6,10 +6,14 @@ filebeat:
   registry_file: /local/.filebeat
   prospectors:
     - input_type: log
+    {{ if ne (var "APPTYPE") "nginx" }}
       json:
         key_under_root: true
         overwrite_keys: true
         add_error_key: true
+    {{ else }}
+      document_type: nginx_access
+    {{ end }}
       paths:
         - /alloc/logs/*.stdout.*
       exclude_files:
@@ -24,10 +28,14 @@ filebeat:
           {{ if $meta_vars }}meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}{{ end }}
 {{ if eq (var "EXCLUDE_STDERR") "" }}    - input_type: log
+    {{ if ne (var "APPTYPE") "nginx" }}
       json:
         key_under_root: true
         overwrite_keys: true
         add_error_key: true
+    {{ else }}
+      document_type: nginx_error
+    {{ end }}
       paths:
         - /alloc/logs/*.stderr.*
       exclude_files:

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -1,8 +1,15 @@
+{{ if var "NAME" }}name: {{ var "NAME" }}{{ else }}#name:{{ end }}
+{{ if var "TAGS" }}tags:{{ range var "TAGS" | split "," }}
+  - "{{ . }}"{{ end }}{{ else }} []{{ end }}
+
 filebeat:
   registry_file: /local/.filebeat
   prospectors:
     - input_type: log
-      document_type: {{ var "DOCUMENT_TYPE" | default "log" }}
+      json:
+        key_under_root: true
+        overwrite_keys: true
+        add_error_key: true
       paths:
         - /alloc/logs/*.stdout.*
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
@@ -14,7 +21,10 @@ filebeat:
           {{ if $meta_vars }}meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}{{ end }}
 {{ if eq (var "EXCLUDE_STDERR") "" }}    - input_type: log
-      document_type: {{ var "DOCUMENT_TYPE" | default "log" }}
+      json:
+        key_under_root: true
+        overwrite_keys: true
+        add_error_key: true
       paths:
         - /alloc/logs/*.stderr.*
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
@@ -25,11 +35,6 @@ filebeat:
           {{ if var . }}{{ . | replace "NOMAD_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
           {{ if $meta_vars }}meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}
-
-shipper:
-  {{ if var "NAME" }}name: {{ var "NAME" }}{{ else }}#name:{{ end }}
-  tags:{{ if var "TAGS" }}{{ range var "TAGS" | split "," }}
-    - "{{ . }}"{{ end }}{{ else }} []{{ end }}
 
 output:
 {{ if var "ES_HOST" }}  elasticsearch:
@@ -53,5 +58,6 @@ output:
     password: {{ var "REDIS_PASSWORD" | default "~" }}{{ end }}
 
 logging:
+  level: warning
   to_files: false
   to_syslog: false

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -12,6 +12,8 @@ filebeat:
         add_error_key: true
       paths:
         - /alloc/logs/*.stdout.*
+      exclude_files
+        - nomadbeat
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
       fields:
         stream: stdout
@@ -27,6 +29,8 @@ filebeat:
         add_error_key: true
       paths:
         - /alloc/logs/*.stderr.*
+      exclude_files
+        - nomadbeat
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
       fields:
         stream: stderr
@@ -40,10 +44,11 @@ output:
 {{ if var "ES_HOST" }}  elasticsearch:
     hosts:{{ range var "ES_HOST" | split "," }}
       - "{{ . }}"{{ end }}
-    index: {{ var "ES_INDEX" | default "filebeat" }}
+    index: {{ var "ES_INDEX" | default "logs-%{+yyyy.MM.dd}" }}
     protocol: {{ var "ES_PROTOCOL" | default "http" }}
     username: {{ var "ES_USERNAME" | default "~" }}
     password: {{ var "ES_PASSWORD" | default "~" }}{{ end }}
+    template.enabled: false
 {{ if var "LOGSTASH_HOST" }}  logstash:
     hosts:{{ if var "LOGSTASH_HOST" }}{{ range var "LOGSTASH_HOST" | split "," }}
       - "{{ . }}"{{ end }}{{else}} []{{end}}

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -12,11 +12,12 @@ filebeat:
         add_error_key: true
       paths:
         - /alloc/logs/*.stdout.*
-      exclude_files
+      exclude_files:
         - nomadbeat
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
       fields:
         stream: stdout
+        type: {{ var "DOCUMENT_TYPE" | default "log" }}
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if or $nomad_vars $meta_vars }}nomad:{{ if $nomad_vars }}{{ range $nomad_vars | split "," }}
           {{ if var . }}{{ . | replace "NOMAD_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}
@@ -29,11 +30,12 @@ filebeat:
         add_error_key: true
       paths:
         - /alloc/logs/*.stderr.*
-      exclude_files
+      exclude_files:
         - nomadbeat
       fields_under_root: {{ var "FIELDS_UNDER_ROOT" | default "true" }}
       fields:
         stream: stderr
+        type: {{ var "DOCUMENT_TYPE" | default "log" }}
         {{ if var "ENVIRONMENT" }}environment: {{ var "ENVIRONMENT" }}{{ else }}#environment:{{ end }}
         {{ if or $nomad_vars $meta_vars }}nomad:{{ if $nomad_vars }}{{ range $nomad_vars | split "," }}
           {{ if var . }}{{ . | replace "NOMAD_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}


### PR DESCRIPTION
## O que este PR faz?
docker-nomad-filebeat: add fix log treatment in filebeat template for api-router
    
    api-router dont generate json logs, so, nomad-beat dont get this logs
    because settings in filebeat template is only applied to get json.
    The commit add a conditional when var APPTYPE is nginx, removing
    settings json and add settings nginx.

## Documentação de Impacto
None

### Quais módulos ou funcionalidades poderão ser afetados por esta alteração?
nomad-beat 

### Quais podem ser os impactos ou comportamento dos serviços em caso de falha?
Dont get logs

## Testes de funcionalidade e análise estática
None

## Envolve migration ou outros projetos em paralelo?
None

## O rollback deste PR envolve algum passo adicional além de um Revert?
None
